### PR TITLE
Improvements

### DIFF
--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "BepInEx_GUI",
-    "version_number": "3.0.0",
+    "version_number": "3.0.1",
     "website_url": "https://github.com/risk-of-thunder/BepInEx.GUI",
     "description": "Graphical User Interface meant to replace the regular console host that is used by BepInEx when the config setting is enabled.",
     "dependencies": []

--- a/bepinex_gui/Cargo.lock
+++ b/bepinex_gui/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bepinex_gui"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "byteorder",
  "clipboard",

--- a/bepinex_gui/Cargo.toml
+++ b/bepinex_gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bepinex_gui"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Risk of Thunder"]
 license = "MIT"
 description = "Graphical User Interface meant to replace the regular console host that is used by BepInEx"

--- a/bepinex_gui/src/data/bepinex_log/mod.rs
+++ b/bepinex_gui/src/data/bepinex_log/mod.rs
@@ -59,9 +59,11 @@ impl Numeric for LogLevel {
     }
 }
 
+#[derive(Clone)]
 pub struct BepInExLogEntry {
     level: LogLevel,
     data: String,
+    data_lowercase: String,
     pub is_selected: bool,
 }
 
@@ -69,7 +71,8 @@ impl BepInExLogEntry {
     pub fn new(level: LogLevel, data: String) -> Self {
         Self {
             level,
-            data,
+            data: data.clone(),
+            data_lowercase: data.to_lowercase(),
             is_selected: false,
         }
     }
@@ -80,5 +83,9 @@ impl BepInExLogEntry {
 
     pub fn data(&self) -> &str {
         self.data.as_ref()
+    }
+
+    pub fn data_lowercase(&self) -> &str {
+        self.data_lowercase.as_ref()
     }
 }

--- a/bepinex_gui/src/data/bepinex_log/receiver.rs
+++ b/bepinex_gui/src/data/bepinex_log/receiver.rs
@@ -19,20 +19,20 @@ use super::LogLevel;
 #[derive(Clone)]
 pub struct LogReceiver {
     log_socket_port_receiver: u16,
-    log_sender: Sender<BepInExLogEntry>,
-    mod_sender: Sender<BepInExMod>,
+    log_senders: Vec<Sender<BepInExLogEntry>>,
+    mod_senders: Vec<Sender<BepInExMod>>,
 }
 
 impl LogReceiver {
     pub fn new(
         log_socket_port_receiver: u16,
-        log_sender: Sender<BepInExLogEntry>,
-        mod_sender: Sender<BepInExMod>,
+        log_senders: Vec<Sender<BepInExLogEntry>>,
+        mod_senders: Vec<Sender<BepInExMod>>,
     ) -> LogReceiver {
         LogReceiver {
             log_socket_port_receiver,
-            log_sender,
-            mod_sender,
+            log_senders,
+            mod_senders,
         }
     }
 
@@ -112,12 +112,16 @@ impl LogReceiver {
                 let mod_version =
                     &mod_info_text[mod_version_start_index + 1..mod_info_text.len() - 1];
 
-                self.mod_sender
-                    .send(BepInExMod::new(mod_name, mod_version))
-                    .unwrap();
+                for mod_sender in &self.mod_senders {
+                    mod_sender
+                        .send(BepInExMod::new(mod_name, mod_version))
+                        .unwrap();
+                }
             }
         }
 
-        self.log_sender.send(log).unwrap();
+        for log_sender in &self.log_senders {
+            log_sender.send(log.clone()).unwrap();
+        }
     }
 }

--- a/bepinex_gui/src/views/utils/egui/mod.rs
+++ b/bepinex_gui/src/views/utils/egui/mod.rs
@@ -24,21 +24,22 @@ pub(crate) fn compute_text_size(
 }
 
 pub(crate) fn scroll_when_trying_to_select_stuff_above_or_under_rect(ui: &mut Ui, clip_rect: Rect) {
-    // if self.button_currently_down && !ui.rect_contains_pointer(clip_rect) {
     if !ui.rect_contains_pointer(clip_rect) {
-        let mut scroll = Vec2::new(0., 0.);
-        let dist = clip_rect.bottom() - ui.input(|i| i.pointer.interact_pos().unwrap().y);
+        if let Some(interact_pos) = ui.input(|i| i.pointer.interact_pos()) {
+            let mut scroll = Vec2::new(0., 0.);
+            let dist = clip_rect.bottom() - interact_pos.y;
 
-        const SCROLL_SPEED: f32 = 0.0010;
+            const SCROLL_SPEED: f32 = 0.5;
 
-        if dist < 0. {
-            scroll.y = dist;
-            scroll.y *= SCROLL_SPEED;
-        } else if dist > 0. {
-            scroll.y = clip_rect.top() - ui.input(|i| i.pointer.interact_pos().unwrap().y);
-            scroll.y *= SCROLL_SPEED;
+            if dist < 0. {
+                scroll.y = dist;
+                scroll.y *= SCROLL_SPEED;
+            } else if dist > 0. {
+                scroll.y = clip_rect.top() - interact_pos.y;
+                scroll.y *= SCROLL_SPEED;
+            }
+
+            ui.scroll_with_delta(scroll);
         }
-
-        ui.scroll_with_delta(scroll);
     }
 }


### PR DESCRIPTION
General fix:

Fix sometimes the loaded mod list being incorrect, whether in the general tab or the console tab

Console Tab:

- Big performance upgrade due to caching on first render the height of eaach individual log entries inside the ScrollArea of the console, this allow for rendering only whats visible within the console view.
- Fix a bug where the scroll speed while selecting log entries was inconsistent depending on the content of the visible content of the console.
- Cache the lower case version of log entries, should make text filtering much faster at the small cost of memory.

